### PR TITLE
Version 1.x Scaffolding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        php: ['7.4', '8.0']
+        laravel: ['8.12', '8.40']
+    name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Installing PHP
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, json, sqlite3
+          tools: composer:v2
+      - name: Lock Laravel Version
+        run: composer require "illuminate/support:${{ matrix.laravel }}.*" --no-update -v && composer require "illuminate/console:${{ matrix.laravel }}.*" --no-update -v
+      - name: Composer Install
+        run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Check Coding Style
+        run: vendor/bin/phpcs --standard=phpcs.xml
+      - name: Run Tests
+        run: php vendor/bin/phpunit --testdox

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor
 .idea
+composer.lock
+/.phpunit.result.cache

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,15 @@
+# Gimmersta Proxicore Package Changelog
+
+## Unreleased
+##### 2021-XX-YY
+
+- Dropped PHP 7.0 - 7.3 support
+- Dropped Laravel 5.4 - 7.x support
+- Changed minimum Laravel version to 8.12
+- Added explicit Guzzle requirement (it was needed even earlier, but was missing from composer.json)
+
+## 0.0.3.7
+##### 2021-03-09
+
+- Supports Laravel 5.4 - 8.x
+- Supports PHP 7.0+

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "9.4.*",
-        "orchestra/testbench": "^6.0"
+        "orchestra/testbench": "^6.0",
+        "squizlabs/php_codesniffer": "^3.6",
+        "slevomat/coding-standard": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,9 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "^9.0"
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "9.4.*",
+        "orchestra/testbench": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "require": {
         "php": ">=7.0",
         "laravel/framework": "^5.4|^6.0|^7.0|^8.0",
+        "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "ext-curl": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "laravel",
         "proxicore"
     ],
-    "license": "MIT",
+    "license": "proprietary",
     "authors": [
         {
             "name": "Edward Karlsson",
@@ -15,17 +15,21 @@
         {
             "name": "Daniel Nordström",
             "email": "daniel@rebelwalls.com"
+        },
+        {
+            "name": "Attila Fülöp",
+            "email": "attila@artkonekt.com"
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "laravel/framework": "^5.4|^6.0|^7.0|^8.0",
+        "php": "^7.4|^8.0",
+        "laravel/framework": "^8.12",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "ext-curl": "*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
             "providers": [
                 "RebelWalls\\LaravelProxicore\\ServiceProvider"
             ]
+        },
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
         }
     }
 }

--- a/helpers.php
+++ b/helpers.php
@@ -11,13 +11,18 @@ if (! function_exists('concat_uri')) {
      *
      * @return string
      */
-    function concat_uri(...$paths)
+    function concat_uri(string ...$paths)
     {
         return concat_uri_array($paths);
     }
 }
 
 if (! function_exists('concat_uri_array')) {
+    /**
+     * @param array $paths
+     *
+     * @return false|mixed|string
+     */
     function concat_uri_array(array $paths)
     {
         $SEPARATOR = '/';

--- a/helpers.php
+++ b/helpers.php
@@ -24,11 +24,11 @@ if (! function_exists('concat_uri_array')) {
         $result = '';
 
         foreach ($paths as $path) {
-            while(substr($path, -1) == $SEPARATOR) { // remove all trailing slashes
+            while (substr($path, -1) == $SEPARATOR) { // remove all trailing slashes
                 $path = substr($path, 0, -1);
             }
 
-            while(substr($path, 0,1) == $SEPARATOR) { // remove all prefix slashes
+            while (substr($path, 0, 1) == $SEPARATOR) { // remove all prefix slashes
                 $path = substr($path, 1);
             }
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<ruleset name="Gimmersta Coding Standard">
+  <description>The Gimmersta Coding Standard</description>
+  <rule ref="PSR12"/>
+  <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+    <exclude-pattern>database/</exclude-pattern>
+  </rule>
+  <rule ref="Generic.Files.LineLength.TooLong">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.BlockComment">
+      <exclude name="Squiz.Commenting.BlockComment.WrongStart" />
+  </rule>
+  <rule ref="Squiz.Commenting.ClassComment"/>
+  <rule ref="Squiz.Commenting.ClassComment.Missing">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.DocCommentAlignment"/>
+  <rule ref="Squiz.Commenting.FunctionComment"/>
+  <rule ref="Squiz.Commenting.FunctionComment.MissingParamComment">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.FunctionComment.EmptyThrows">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.FunctionComment.TypeHintMissing">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.FunctionComment.SpacingAfterParamType">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.FunctionComment.SpacingAfterParamType">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.FunctionComment.SpacingAfterParamName">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
+      <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.BlockComment.NoEmptyLineAfter">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.ClassComment.TagNotAllowed">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
+  <rule ref="Squiz.Commenting.InlineComment"/>
+  <rule ref="Squiz.Commenting.VariableComment"/>
+  <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
+  <config name="installed_paths"
+          value="../../slevomat/coding-standard"/>
+  <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+    <properties>
+      <property name="searchAnnotations" type="bool" value="true"/>
+    </properties>
+  </rule>
+  <file>src/</file>
+  <file>config/</file>
+  <file>tests/</file>
+  <exclude-pattern>vendor</exclude-pattern>
+  <exclude-pattern>node_modules/</exclude-pattern>
+  <exclude-pattern>*.blade.php</exclude-pattern>
+  <exclude-pattern>*.js</exclude-pattern>
+  <exclude-pattern>*.css</exclude-pattern>
+</ruleset>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix="Test.php">tests/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Larave Proxicore Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/Api/ProxicoreApi.php
+++ b/src/Api/ProxicoreApi.php
@@ -101,7 +101,7 @@ abstract class ProxicoreApi
     /**
      * @var string
      */
-    protected $endpoint;
+    protected string $endpoint;
 
     /**
      * Compiles the API uri with the endpoint and optional parameters
@@ -162,8 +162,12 @@ abstract class ProxicoreApi
      * @param string $method
      * @param string $endpoint
      */
-    protected function handleLog(ProxicoreApiResponse $responseObject, array $parameters, string $method, string $endpoint): void
-    {
+    protected function handleLog(
+        ProxicoreApiResponse $responseObject,
+        array $parameters,
+        string $method,
+        string $endpoint
+    ): void {
         try {
             $parameterString = collect($parameters)
                 ->transform(function ($value, $key) {
@@ -171,7 +175,7 @@ abstract class ProxicoreApi
                 })
                 ->implode(', ');
 
-            $contextString = 'Method: [' . $method . '] Endpoint: [' . $endpoint . '] Parameters: [' . $parameterString . ']';
+            $contextString = "Method: [$method] Endpoint: [$endpoint] Parameters: [$parameterString]";
 
             switch ($responseObject->getStatus()) {
                 case 'success':

--- a/src/Api/ProxicoreApi.php
+++ b/src/Api/ProxicoreApi.php
@@ -8,10 +8,9 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Log;
+use stdClass;
 
 use function GuzzleHttp\Psr7\stream_for;
-
-use stdClass;
 
 /**
  * Class ProxicoreApi
@@ -38,8 +37,8 @@ abstract class ProxicoreApi
     /**
      * Responsible for making the final API call
      *
-     * @param $method
-     * @param $endpoint
+     * @param string $method
+     * @param string $endpoint
      * @param array $parameters
      * @param null $payload
      *
@@ -47,7 +46,7 @@ abstract class ProxicoreApi
      *
      * @throws ProxicoreException
      */
-    protected function call($method, $endpoint, $parameters = [], $payload = null)
+    protected function call(string $method, string $endpoint, $parameters = [], $payload = null)
     {
         try {
             $uri = $this->createUri($endpoint, $parameters);
@@ -106,12 +105,12 @@ abstract class ProxicoreApi
     /**
      * Compiles the API uri with the endpoint and optional parameters
      *
-     * @param $endpoint
+     * @param string $endpoint
      * @param null $params
      *
      * @return string
      */
-    private function createUri($endpoint, $params = null)
+    private function createUri(string $endpoint, $params = null)
     {
         $uri = concat_uri(
             config('laravel-proxicore.endpoint'),
@@ -161,6 +160,8 @@ abstract class ProxicoreApi
      * @param array $parameters
      * @param string $method
      * @param string $endpoint
+     *
+     * @return void
      */
     protected function handleLog(
         ProxicoreApiResponse $responseObject,

--- a/src/Api/ProxicoreApi.php
+++ b/src/Api/ProxicoreApi.php
@@ -8,7 +8,9 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Log;
+
 use function GuzzleHttp\Psr7\stream_for;
+
 use stdClass;
 
 /**

--- a/src/Api/ProxicoreApiResponse.php
+++ b/src/Api/ProxicoreApiResponse.php
@@ -88,7 +88,7 @@ class ProxicoreApiResponse
     }
 
     /**
-     * @return bool
+     * @return boolean
      */
     public function success()
     {

--- a/src/Api/ProxicoreApiResponse.php
+++ b/src/Api/ProxicoreApiResponse.php
@@ -49,6 +49,8 @@ class ProxicoreApiResponse
      * Handle response
      *
      * @throws ProxicoreException
+     *
+     * @return void
      */
     private function handle()
     {

--- a/src/Api/ProxicoreMessageApi.php
+++ b/src/Api/ProxicoreMessageApi.php
@@ -15,9 +15,7 @@ use RebelWalls\LaravelProxicore\MessagePusher\BaseMessage;
  */
 class ProxicoreMessageApi extends ProxicoreApi
 {
-    /**
-     * Api endpoint
-     */
+    /** @var string Api endpoint */
     protected string $endpoint = 'publishevent';
 
     /**

--- a/src/Api/ProxicoreMessageApi.php
+++ b/src/Api/ProxicoreMessageApi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RebelWalls\LaravelProxicore\Api;
 
 use RebelWalls\LaravelProxicore\MessagePusher\BaseMessage;
@@ -16,7 +18,7 @@ class ProxicoreMessageApi extends ProxicoreApi
     /**
      * Api endpoint
      */
-    protected $endpoint = 'publishevent';
+    protected string $endpoint = 'publishevent';
 
     /**
      * @param BaseMessage $message
@@ -28,8 +30,6 @@ class ProxicoreMessageApi extends ProxicoreApi
      */
     public function push(BaseMessage $message)
     {
-//        info('Pushing Proxicore Api call to [' . $this->endpoint . '] with payload: ' . json_encode($message->toArray(), JSON_PRETTY_PRINT), ['traceId' => $message->getTraceId()]);
-
         return $this->post($this->endpoint, [], $message->toArray());
     }
 }

--- a/src/Calls/ProxicoreGetPaymentStatusCall.php
+++ b/src/Calls/ProxicoreGetPaymentStatusCall.php
@@ -2,7 +2,6 @@
 
 namespace RebelWalls\LaravelProxicore\Calls;
 
-use GuzzleHttp\Exception\GuzzleException;
 use RebelWalls\LaravelProxicore\Api\ProxicoreApiResponse;
 use RebelWalls\LaravelProxicore\Api\ProxicoreException;
 

--- a/src/MessagePusher/BaseMessage.php
+++ b/src/MessagePusher/BaseMessage.php
@@ -54,7 +54,7 @@ abstract class BaseMessage
 
         return $this->traceId;
     }
-    
+
     /**
      * @param array $payload
      *

--- a/src/MessagePusher/BaseMessage.php
+++ b/src/MessagePusher/BaseMessage.php
@@ -95,6 +95,8 @@ abstract class BaseMessage
 
     /**
      * If a traceable id is not set, create a backup traceable id.
+     *
+     * @return void
      */
     private function ensureTraceableIdIsSet()
     {

--- a/src/MessagePusher/BaseMessage.php
+++ b/src/MessagePusher/BaseMessage.php
@@ -75,7 +75,13 @@ abstract class BaseMessage
         $this->ensureTraceableIdIsSet();
 
         if (empty($this->payload)) {
-            Log::warning('Payload for Proxicore Message [' . $this->traceId . '] was empty.', ['traceId' => $this->traceId]);
+            Log::warning(
+                sprintf(
+                    'Payload for Proxicore Message [%s] was empty.',
+                    $this->traceId
+                ),
+                ['traceId' => $this->traceId]
+            );
         }
 
         return [

--- a/src/MessagePusher/MessagePusher.php
+++ b/src/MessagePusher/MessagePusher.php
@@ -43,7 +43,12 @@ class MessagePusher
 
             return new MessageResponse($response);
         } catch (Throwable $throwable) {
-            Log::emergency('Unable to send message to Proxicore. Message returned in Proxicore response: [' . $throwable->getMessage() . ']');
+            Log::emergency(
+                sprintf(
+                    'Unable to send message to Proxicore. Message returned in Proxicore response: [%s]',
+                    $throwable->getMessage()
+                )
+            );
         }
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,7 +17,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/laravel-proxicore.php', 'laravel-proxicore'
+            __DIR__ . '/../config/laravel-proxicore.php',
+            'laravel-proxicore'
         );
     }
 

--- a/tests/AAASmokeTest.php
+++ b/tests/AAASmokeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RebelWalls\LaravelProxicore\Tests;
+
+class AAASmokeTest extends TestCase
+{
+    public const MIN_PHP_VERSION = '7.4.0';
+
+    /**
+     * @test
+     * @return void
+     */
+    public function smoke()
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Test for minimum PHP version
+     *
+     * @depends smoke
+     * @return void
+     */
+    public function testPhpVersionSatisfiesRequirements()
+    {
+        $this->assertFalse(
+            version_compare(PHP_VERSION, self::MIN_PHP_VERSION, '<'),
+            'PHP version ' . self::MIN_PHP_VERSION . ' or greater is required but only '
+            . PHP_VERSION . ' found.'
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RebelWalls\LaravelProxicore\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra
+{
+
+}


### PR DESCRIPTION
This PR prepares version 1.x of this library.

- Marked branch as 1.x-dev so that we we can early-start testing/integrating it
- Dropped PHP 7.0 - 7.3 support
- Dropped Laravel 5.4 - 7.x support
- Added test suite
- Added Coding Standards checking (Gimmersta ruleset)
- Fixed Gimmersta Coding Standards violations
- Added CI configuration
- Changed minimum Laravel version to 8.12
- Added explicit Guzzle requirement (it was needed even earlier, but was missing from composer.json)
- Added Changelog