### PR TITLE
Replace Guzzle with HTTP Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "php": "^7.4|^8.0",
         "laravel/framework": "^8.12",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
@@ -36,12 +37,16 @@
     },
     "autoload": {
         "psr-4": {
-            "RebelWalls\\LaravelProxicore\\": "src/",
-            "RebelWalls\\LaravelProxicore\\Tests\\": "tests/"
+            "RebelWalls\\LaravelProxicore\\": "src/"
         },
         "files": [
             "helpers.php"
         ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "RebelWalls\\LaravelProxicore\\Tests\\": "tests/"
+        }
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/helpers.php
+++ b/helpers.php
@@ -7,11 +7,11 @@ if (! function_exists('concat_uri')) {
      * Manages prefix and trailing slashes
      * Output ex. http://volumes/hello
      *
-     * @param string ...$paths
+     * @param null|string ...$paths
      *
      * @return string
      */
-    function concat_uri(string ...$paths)
+    function concat_uri(?string ...$paths)
     {
         return concat_uri_array($paths);
     }

--- a/tests/AAASmokeTest.php
+++ b/tests/AAASmokeTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace RebelWalls\LaravelProxicore\Tests;
 
-class AAASmokeTest extends TestCase
+use PHPUnit\Framework\TestCase as PhpUnitTestCase;
+
+class AAASmokeTest extends PhpUnitTestCase
 {
     public const MIN_PHP_VERSION = '7.4.0';
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,5 +8,28 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     *
+     * @return string[]
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            "RebelWalls\\LaravelProxicore\\ServiceProvider",
+        ];
+    }
 
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     *
+     * @return void
+     */
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']->set('laravel-proxicore.endpoint', 'http://api.test/');
+        $app['config']->set('laravel-proxicore.origin', 'cronos');
+    }
 }

--- a/tests/Unit/PaymentStatusTest.php
+++ b/tests/Unit/PaymentStatusTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RebelWalls\LaravelProxicore\Tests\Unit;
+
+use Illuminate\Support\Facades\Http;
+use RebelWalls\LaravelProxicore\Api\ProxicoreApiResponse;
+use RebelWalls\LaravelProxicore\Calls\ProxicoreGetPaymentStatusCall;
+use RebelWalls\LaravelProxicore\Tests\TestCase;
+
+class PaymentStatusTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testCanProcessTheHttpResponse()
+    {
+        Http::fake([
+            'api.test/*' => Http::response(['status' => 200, 'payload' => []], 200)
+        ]);
+        $paymentStatusCall = new ProxicoreGetPaymentStatusCall();
+
+        $this->assertInstanceOf(ProxicoreApiResponse::class, $paymentStatusCall->getPaymentStatus('1'));
+    }
+}


### PR DESCRIPTION
- Replaced the core HTTP client call from guzzle to [Laravel's HTTP client](https://laravel.com/docs/8.x/http-client)
- Added a simple test case